### PR TITLE
Avoid busybox awk syntax error

### DIFF
--- a/captive-portal.sh
+++ b/captive-portal.sh
@@ -318,7 +318,9 @@ main() {
     portal_url=$(awk "
       BEGIN{IGNORECASE=1}
       /https?:\\/\\/[^\"' ]*(splash|login|portal|guest|captive|network-auth)[^\"' ]*/ {
-        match(\$0, /https?:\\/\\/[^\"' )]+/, m); print m[0]; exit
+        if (match(\$0, /https?:\\/\\/[^\"' )]+/)) {
+          print substr(\$0, RSTART, RLENGTH); exit
+        }
       }" "$html_file")
   else
     portal_url="$location"


### PR DESCRIPTION
## Summary
- avoid use of non-POSIX third argument in `match` when parsing portal URLs

## Testing
- `bash -n captive-portal.sh`
- `bash captive-portal.sh` *(fails to detect portal due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_68c75e5fa2d48326b261a6653adcd064